### PR TITLE
begin to store provider url state

### DIFF
--- a/src/components/Cards/OverlayCard.tsx
+++ b/src/components/Cards/OverlayCard.tsx
@@ -5,7 +5,6 @@ import {
   LowCostSensorMarker,
 } from '../LocationMarker';
 import { useStore } from '~/stores';
-import { createSignal } from 'solid-js';
 
 import '~/assets/scss/components/overlay-card.scss';
 
@@ -39,7 +38,7 @@ export function OverlayCard() {
             name="parameter-select"
             id="parameter-select"
             onChange={(e) => setSelectedMapParameter(e.target.value)}
-            value={'all'}
+            value={store.mapParameter.toString()}
           >
             <option value="all">Any pollutant</option>
             <option value="pm25">PM&#8322;&#8325;</option>

--- a/src/components/Cards/ProvidersCard.tsx
+++ b/src/components/Cards/ProvidersCard.tsx
@@ -1,19 +1,12 @@
-import { useStore } from '~/stores';
+import { useStore } from "~/stores";
 
-import {
-  For,
-  Show,
-  createSignal,
-  onMount,
-  createEffect,
-} from 'solid-js';
-import { getProviders } from '~/client';
-import MiniSearch from 'minisearch';
-import bbox from '@turf/bbox';
-import { createStore, produce } from 'solid-js/store';
+import { For, Show, createSignal, onMount, createEffect } from "solid-js";
+import { getProviders } from "~/client";
+import MiniSearch from "minisearch";
+import bbox from "@turf/bbox";
+import { createStore, produce } from "solid-js/store";
 
-import '~/assets/scss/components/providers-card.scss';
-
+import "~/assets/scss/components/providers-card.scss";
 
 interface ProvidersStoreDefinition {
   name: string;
@@ -27,12 +20,7 @@ interface ProvidersStoreDefinition {
 export function ProvidersCard() {
   const [
     store,
-    {
-      toggleShowProvidersCard,
-      setViewport,
-      setProviders,
-      setTotalProviders,
-    },
+    { toggleShowProvidersCard, setViewport, setProviders, setTotalProviders },
   ] = useStore();
 
   const [count, setCount] = createSignal();
@@ -47,8 +35,8 @@ export function ProvidersCard() {
   };
 
   const miniSearch = new MiniSearch({
-    fields: ['name'],
-    storeFields: ['name'],
+    fields: ["name"],
+    storeFields: ["name"],
   });
 
   let timeout: ReturnType<typeof setTimeout>;
@@ -56,13 +44,13 @@ export function ProvidersCard() {
   const onSearchInput = (e: InputEvent) => {
     clearTimeout(timeout);
     timeout = setTimeout(() => {
-      const target = e.target as HTMLInputElement
+      const target = e.target as HTMLInputElement;
       const value = target.value;
       const res = miniSearch.search(value, { prefix: true });
       setSelectedProviders(
         () => true,
         produce((provider) =>
-          value != ''
+          value != ""
             ? (provider.matchesQuery =
                 res.map((o) => o.id).indexOf(provider.id) != -1)
             : (provider.matchesQuery = true)
@@ -82,7 +70,10 @@ export function ProvidersCard() {
           return {
             name: o.name,
             id: o.id,
-            checked: store.providers.includes(o.id),
+            checked:
+              store.providers.length === 0
+                ? "true"
+                : store.providers.includes(o.id),
             matchesQuery: true,
             bbox: o.bbox,
           };

--- a/src/components/Cards/ProvidersCard.tsx
+++ b/src/components/Cards/ProvidersCard.tsx
@@ -35,6 +35,7 @@ export function ProvidersCard() {
   ] = useStore();
 
   const [count, setCount] = createSignal();
+
   const [selectedProviders, setSelectedProviders] = createStore<
     ProvidersStoreDefinition[]
   >([]);

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,20 +1,25 @@
-import { Map } from '~/components/Map';
-import { getUserId } from '~/db';
-import { LocationDetailCard } from '~/components/Cards/LocationDetailCard';
-import { FlipCard } from '~/components/Cards/FlipCard';
-import { Header } from '~/components/Header';
+import { Map } from "~/components/Map";
+import { getUserId } from "~/db";
+import { LocationDetailCard } from "~/components/Cards/LocationDetailCard";
+import { FlipCard } from "~/components/Cards/FlipCard";
+import { Header } from "~/components/Header";
 
-import '~/assets/scss/routes/index.scss';
-import { useLocation, useNavigate } from '@solidjs/router';
-import { useStore } from '~/stores';
-import { createEffect, onMount } from 'solid-js';
+import "~/assets/scss/routes/index.scss";
+import { useLocation, useNavigate } from "@solidjs/router";
+import { useStore } from "~/stores";
+import { createEffect, createMemo, onMount } from "solid-js";
+
 
 export const route = {
   load: () => getUserId(),
 };
 
 export default function Home() {
-  const [store, { setSelectedLocationsId }] = useStore();
+  const [store, actions] = useStore();
+
+  const setSelectedLocationsId = actions.setSelectedLocationsId;
+  const setSelectedMapParameter = actions.setSelectedMapParameter;
+  const setProviders = actions.setProviders;
 
   const location = useLocation();
   const navigate = useNavigate();
@@ -23,14 +28,45 @@ export default function Home() {
     if (location.query.location) {
       setSelectedLocationsId(Number(location.query.location));
     }
-  })
+
+    if (location.query?.parameter) {
+      setSelectedMapParameter(Number(location.query.parameter));
+    }
+
+    if (location.query?.provider) {
+      const params = new URLSearchParams(location.search);
+      const providersArray = params.get("provider")?.split(",").map(providerId => Number(providerId));  
+      providersArray && setProviders(providersArray);
+    }
+  });
 
   createEffect(() => {
+    const getProviders = createMemo(() => store.providers);
+    const providers = getProviders();
+    
+    console.log("store providers in the index route", store.providers);
+
+    const searchParams = new URLSearchParams();
+
     if (store.locationsId !== undefined) {
-      navigate(`${location.pathname}?location=${store.locationsId}${location.hash}`);
-    } else {
-      navigate(`${location.pathname}${location.hash}`);
+      searchParams.append("location", store.locationsId.toString());
     }
+
+    if (store.mapParameter !== "all") {
+      searchParams.append("parameter", store.mapParameter);
+    }
+
+    if (providers.length > 0) {
+      console.log("providers in the index route", providers);
+      searchParams.append("provider", store.providers.join(","));
+    }
+
+    const queryString = searchParams.toString();
+    const path = queryString
+      ? `${location.pathname}?${queryString}${location.hash}`
+      : `${location.pathname}${location.hash}`;
+
+    navigate(path);
   });
 
   return (

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -30,7 +30,7 @@ export default function Home() {
     }
 
     if (location.query?.parameter) {
-      setSelectedMapParameter(Number(location.query.parameter));
+      setSelectedMapParameter(location.query.parameter);
     }
 
     if (location.query?.provider) {
@@ -44,8 +44,6 @@ export default function Home() {
     const getProviders = createMemo(() => store.providers);
     const providers = getProviders();
     
-    console.log("store providers in the index route", store.providers);
-
     const searchParams = new URLSearchParams();
 
     if (store.locationsId !== undefined) {
@@ -53,11 +51,10 @@ export default function Home() {
     }
 
     if (store.mapParameter !== "all") {
-      searchParams.append("parameter", store.mapParameter);
+      searchParams.append("parameter", store.mapParameter.toString());
     }
 
     if (providers.length > 0) {
-      console.log("providers in the index route", providers);
       searchParams.append("provider", store.providers.join(","));
     }
 

--- a/src/stores/index.tsx
+++ b/src/stores/index.tsx
@@ -143,7 +143,6 @@ export const StoreProvider: Component<{}> = (props) => {
         });
       },
       setProviders(providers) {
-        console.log("providers in store function", providers);
         setState({ providers: providers });
       },
       setTotalProviders(totalProviders: number) {

--- a/src/stores/index.tsx
+++ b/src/stores/index.tsx
@@ -1,16 +1,6 @@
 import { createContext, useContext, Component } from "solid-js";
 import { createStore, produce } from "solid-js/store";
 import { Viewport } from "solid-map-gl";
-// import MiniSearch from "minisearch";
-
-// export interface ProvidersStoreDefinition {
-//   name: string;
-//   locationsCount: number;
-//   id: number;
-//   checked: boolean;
-//   matchesQuery: boolean;
-//   bbox: number[];
-// }
 
 type Store = [
   {

--- a/src/stores/index.tsx
+++ b/src/stores/index.tsx
@@ -1,6 +1,16 @@
-import { createContext, useContext, Component } from 'solid-js';
-import { createStore } from 'solid-js/store';
-import { Viewport } from 'solid-map-gl';
+import { createContext, useContext, Component } from "solid-js";
+import { createStore, produce } from "solid-js/store";
+import { Viewport } from "solid-map-gl";
+// import MiniSearch from "minisearch";
+
+// export interface ProvidersStoreDefinition {
+//   name: string;
+//   locationsCount: number;
+//   id: number;
+//   checked: boolean;
+//   matchesQuery: boolean;
+//   bbox: number[];
+// }
 
 type Store = [
   {
@@ -31,26 +41,25 @@ type Store = [
   {
     setSelectedLocationsId: () => void;
     clearLocationsId?: () => void;
-    setSelectedMapParameter?: () => void;
+    setSelectedMapParameter: (mapParameter: string) => void;
     setDeleteListsId?: () => void;
-    setDeleteListLocationsId? : () => void;
+    setDeleteListLocationsId?: () => void;
 
-
-    setListParametersId? : () => void;
-    setListParameter? : () => void;
+    setListParametersId?: () => void;
+    setListParameter?: () => void;
 
     clearDeleteListsId?: () => void;
     toggleDeleteListModalOpen?: () => void;
     toggleNewListModalOpen?: () => void;
     toggleEditListModalOpen?: () => void;
-    toggleShowProvidersCard?: () => void;
+    toggleShowProvidersCard: () => void;
     toggleRegenerateKeyModalOpen?: () => void;
-    toggleDeleteListLocationModalOpen? : () => void;
+    toggleDeleteListLocationModalOpen?: () => void;
     setViewport?: () => void;
     toggleMonitor?: () => void;
     toggleAirSensor?: () => void;
     toggleMapIsActive?: () => void;
-    setProviders?: () => void;
+    setProviders: (providers: any[]) => void;
     setRecentMeasurements?: () => void;
     addRecentMeasurements?: () => void;
     updateRecentMeasurements?: () => void;
@@ -134,6 +143,7 @@ export const StoreProvider: Component<{}> = (props) => {
         });
       },
       setProviders(providers) {
+        console.log("providers in store function", providers);
         setState({ providers: providers });
       },
       setTotalProviders(totalProviders: number) {
@@ -166,17 +176,19 @@ export const StoreProvider: Component<{}> = (props) => {
         });
       },
       toggleDeleteListLocationModalOpen() {
-        setState({deleteListLocationModalOpen: !state.deleteListLocationModalOpen})
+        setState({
+          deleteListLocationModalOpen: !state.deleteListLocationModalOpen,
+        });
       },
       setDeleteListLocationsId(listLocationsId: number) {
-        setState({listLocationsId: listLocationsId})
+        setState({ listLocationsId: listLocationsId });
       },
       setListParametersId(parametersId: number) {
-        setState({listParametersId: parametersId})
+        setState({ listParametersId: parametersId });
       },
-      setListParameter(parameter:string ) {
-        setState({listParameter: parameter})
-      }
+      setListParameter(parameter: string) {
+        setState({ listParameter: parameter });
+      },
     },
   ];
 
@@ -188,13 +200,13 @@ export const StoreProvider: Component<{}> = (props) => {
 };
 
 function useStoreContext() {
-  const context = useContext(StoreContext)
+  const context = useContext(StoreContext);
   if (!context) {
-    throw new Error("useStoreContext: cannot find a StoreContext")
+    throw new Error("useStoreContext: cannot find a StoreContext");
   }
-  return context
+  return context;
 }
 
-export function useStore() : Store  {
+export function useStore(): Store {
   return useStoreContext();
 }


### PR DESCRIPTION
[Link to relevant issue](https://github.com/openaq/openaq-explorer/issues/32)

## Problem
We would like to store map parameters and providers in the url as a query, so the URL is easier to share around.

## Solution
* Store the map parameters and providers in the URL
* Add additional type safety to the store to avoid type collisions when passing state between query params and application state
* Move some map param and provider information into the store (from the presentation layer) so that it can be more easily shared between the part of the application that handles the URL and the part of the application that handles state

🍁 <b>Please let me know if this is the exact behavior you are looking for, or if there are changes you would like me to make.</b> 🍁