### PR TITLE
fix http error handling

### DIFF
--- a/src/components/NotFoundMessage/NotFoundMessage.tsx
+++ b/src/components/NotFoundMessage/NotFoundMessage.tsx
@@ -1,8 +1,10 @@
+import { HttpStatusCode } from '@solidjs/start';
 import '~/assets/scss/routes/page-not-found.scss';
 
 export function NotFoundMessage() {
   return (
     <>
+      <HttpStatusCode code={404} />
       <section class="page-404">
         <div class="bubble-lg" />
         <div class="bubble-sm" />

--- a/src/components/NotFoundMessage/NotFoundMessage.tsx
+++ b/src/components/NotFoundMessage/NotFoundMessage.tsx
@@ -1,0 +1,15 @@
+import '~/assets/scss/routes/page-not-found.scss';
+
+export function NotFoundMessage() {
+  return (
+    <>
+      <section class="page-404">
+        <div class="bubble-lg" />
+        <div class="bubble-sm" />
+        <h1 class="type-heading-1">
+          Uh oh! We can't find the page you've requested
+        </h1>
+      </section>
+    </>
+  );
+}

--- a/src/routes/(root)/locations/[id].tsx
+++ b/src/routes/(root)/locations/[id].tsx
@@ -4,15 +4,14 @@ import { DetailCharts } from '~/components/DetailCharts';
 import { Breadcrumbs } from '~/components/Breadcrumbs';
 import { DownloadCard, NotLoggedInFallback } from '~/components/DownloadCard';
 import { LocationDetailOpenGraph } from '~/components/OpenGraph';
-import { Show } from 'solid-js';
+import { ErrorBoundary, Show } from 'solid-js';
 import { useStore } from '~/stores';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import '~/assets/scss/routes/location.scss';
 import { getLocationById, sensorNodeLists } from '~/db/lists';
 import { getSessionUser } from '~/auth/session';
 import { getLocationLicenses } from '~/client';
-import { HttpStatusCode } from '@solidjs/start';
-import NotFound from '~/routes/[...404]';
+import { NotFoundMessage } from '~/components/NotFoundMessage/NotFoundMessage';
 
 export const route = {
   preload: ({ params }: { params: Params }) => {
@@ -46,35 +45,30 @@ export default function Location() {
 
   return (
     <>
-      <Show
-        when={location()}
-        fallback={
-          <>
-            <HttpStatusCode code={404} />
-            <NotFound />
-          </>
-        }
-      >
-        <LocationDetailOpenGraph
-          locationsId={Number(id)}
-          locationName={location()?.name}
-        />
-        <main class="location-main">
-          <Breadcrumbs pageName={location()?.name} />
-          <DetailOverview {...location()} licenses={licenses()} user={user} />
-          <Show when={location().datetimeFirst}>
-            <DetailCharts {...location()} />
-            <section id="download-card" class="download-card">
-              <header class="download-card__header">
-                <h3 class="heading">Download</h3>
-              </header>
-              <Show when={user()?.usersId} fallback={<NotLoggedInFallback />}>
-                <DownloadCard {...location()} />
-              </Show>
-            </section>
-          </Show>
-        </main>
-      </Show>
+      <ErrorBoundary fallback={() => <NotFoundMessage />}>
+        <Show when={location()} fallback={<NotFoundMessage />}>
+          <LocationDetailOpenGraph
+            locationsId={Number(id)}
+            locationName={location()?.name}
+          />
+
+          <main class="location-main">
+            <Breadcrumbs pageName={location()?.name} />
+            <DetailOverview {...location()} licenses={licenses()} user={user} />
+            <Show when={location().datetimeFirst}>
+              <DetailCharts {...location()} />
+              <section id="download-card" class="download-card">
+                <header class="download-card__header">
+                  <h3 class="heading">Download</h3>
+                </header>
+                <Show when={user()?.usersId} fallback={<NotLoggedInFallback />}>
+                  <DownloadCard {...location()} />
+                </Show>
+              </section>
+            </Show>
+          </main>
+        </Show>
+      </ErrorBoundary>
     </>
   );
 }

--- a/src/routes/[...404].jsx
+++ b/src/routes/[...404].jsx
@@ -5,7 +5,6 @@ import { Header } from '~/components/Header';
 export default function NotFound() {
   return (
     <>
-      <Header />
       <main>
         <HttpStatusCode code={404} />
         <section class="page-404">

--- a/src/routes/[...404].jsx
+++ b/src/routes/[...404].jsx
@@ -1,19 +1,15 @@
 import { HttpStatusCode } from '@solidjs/start';
 import '~/assets/scss/routes/page-not-found.scss';
 import { Header } from '~/components/Header';
+import { NotFoundMessage } from '~/components/NotFoundMessage/NotFoundMessage';
 
 export default function NotFound() {
   return (
     <>
+      <HttpStatusCode code={404} />
       <main>
-        <HttpStatusCode code={404} />
-        <section class="page-404">
-          <div class="bubble-lg" />
-          <div class="bubble-sm" />
-          <h1 class="type-heading-1">
-            Uh oh! We can't find the page you've requested
-          </h1>
-        </section>
+        <Header />
+        <NotFoundMessage />
       </main>
     </>
   );


### PR DESCRIPTION
Fixed the 500 error when a location wasn’t found. The error came from getLocationById throwing when it couldn't find the location. I updated the call to catch the error and return null instead and wrapped the output in a Show with a 404 + NotFound fallback so it doesn’t crash the server anymore.

I also removed < Header /> in [...404].jsx because it was showing duplicate headers otherwise.

Resolves #78 